### PR TITLE
feat: Allow UI configuration of generator and forecaster parameters

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,4 +1,16 @@
 import { SignalType } from '@lib/types';
+import { SineWaveParams } from '@lib/generators/SineGenerator';
+import { BrownianMotionParams } from '@lib/generators/BrownianMotionGenerator';
+import { LaggedGradientParams } from '@lib/forecasters/LaggedGradientForecaster';
+
+export interface GeneratorParams {
+  sine: Partial<SineWaveParams>;
+  brownian: Partial<BrownianMotionParams>;
+}
+
+export interface ForecasterParams {
+  laggedGradient: Partial<LaggedGradientParams>;
+}
 
 interface ControlPanelProps {
   signalType: SignalType;
@@ -8,6 +20,10 @@ interface ControlPanelProps {
   playbackSpeed: number;
   onPlaybackSpeedChange: (speed: number) => void;
   currentTime: number;
+  generatorParams: GeneratorParams;
+  onGeneratorParamsChange: (type: SignalType, params: Partial<SineWaveParams> | Partial<BrownianMotionParams>) => void;
+  forecasterParams: ForecasterParams;
+  onForecasterParamsChange: (params: Partial<LaggedGradientParams>) => void;
 }
 
 export function ControlPanel({
@@ -17,9 +33,34 @@ export function ControlPanel({
   onPlayPause,
   playbackSpeed,
   onPlaybackSpeedChange,
-  currentTime
+  currentTime,
+  generatorParams,
+  onGeneratorParamsChange,
+  forecasterParams,
+  onForecasterParamsChange,
 }: ControlPanelProps) {
   const speedOptions = [0.5, 1, 2, 4, 8];
+
+  const handleSineParamChange = (param: keyof SineWaveParams, value: string) => {
+    const numValue = parseFloat(value);
+    if (!isNaN(numValue)) {
+      onGeneratorParamsChange('sine', { ...generatorParams.sine, [param]: numValue });
+    }
+  };
+
+  const handleBrownianParamChange = (param: keyof BrownianMotionParams, value: string) => {
+    const numValue = parseFloat(value);
+    if (!isNaN(numValue)) {
+      onGeneratorParamsChange('brownian', { ...generatorParams.brownian, [param]: numValue });
+    }
+  };
+
+  const handleLaggedGradientParamChange = (param: keyof LaggedGradientParams, value: string) => {
+    const numValue = parseFloat(value);
+    if (!isNaN(numValue)) {
+      onForecasterParamsChange({ ...forecasterParams.laggedGradient, [param]: numValue });
+    }
+  };
 
   return (
     <div className="control-panel">
@@ -49,15 +90,90 @@ export function ControlPanel({
         </div>
       </div>
 
+      {signalType === 'sine' && (
+        <div className="control-section">
+          <h4>Sine Wave Parameters</h4>
+          <div className="param-group">
+            <label>Amplitude:</label>
+            <input
+              type="number"
+              step="0.1"
+              value={generatorParams.sine.amplitude}
+              onInput={(e) => handleSineParamChange('amplitude', (e.target as HTMLInputElement).value)}
+            />
+          </div>
+          <div className="param-group">
+            <label>Frequency (Hz):</label>
+            <input
+              type="number"
+              step="0.1"
+              value={generatorParams.sine.frequency}
+              onInput={(e) => handleSineParamChange('frequency', (e.target as HTMLInputElement).value)}
+            />
+          </div>
+          <div className="param-group">
+            <label>Phase (rad):</label>
+            <input
+              type="number"
+              step="0.1"
+              value={generatorParams.sine.phase}
+              onInput={(e) => handleSineParamChange('phase', (e.target as HTMLInputElement).value)}
+            />
+          </div>
+          <div className="param-group">
+            <label>Offset:</label>
+            <input
+              type="number"
+              step="0.1"
+              value={generatorParams.sine.offset}
+              onInput={(e) => handleSineParamChange('offset', (e.target as HTMLInputElement).value)}
+            />
+          </div>
+        </div>
+      )}
+
+      {signalType === 'brownian' && (
+        <div className="control-section">
+          <h4>Brownian Motion Parameters</h4>
+          <div className="param-group">
+            <label>Volatility:</label>
+            <input
+              type="number"
+              step="0.01"
+              value={generatorParams.brownian.volatility}
+              onInput={(e) => handleBrownianParamChange('volatility', (e.target as HTMLInputElement).value)}
+            />
+          </div>
+          <div className="param-group">
+            <label>Drift:</label>
+            <input
+              type="number"
+              step="0.01"
+              value={generatorParams.brownian.drift}
+              onInput={(e) => handleBrownianParamChange('drift', (e.target as HTMLInputElement).value)}
+            />
+          </div>
+           <div className="param-group">
+            <label>Initial Value:</label>
+            <input
+              type="number"
+              step="0.1"
+              value={generatorParams.brownian.initialValue}
+              onInput={(e) => handleBrownianParamChange('initialValue', (e.target as HTMLInputElement).value)}
+            />
+          </div>
+        </div>
+      )}
+
       <div className="control-section">
         <h3>Playback</h3>
-        <button 
+        <button
           onClick={onPlayPause}
           className={`play-button ${isPlaying ? 'playing' : 'paused'}`}
         >
           {isPlaying ? '⏸️ Pause' : '▶️ Play'}
         </button>
-        
+
         <div className="speed-controls">
           <label>Speed:</label>
           <div className="speed-buttons">
@@ -75,11 +191,35 @@ export function ControlPanel({
       </div>
 
       <div className="control-section">
+        <h4>Forecaster: Lagged Gradient</h4>
+        <div className="param-group">
+          <label>Lookback Period:</label>
+          <input
+            type="number"
+            step="1"
+            min="1"
+            value={forecasterParams.laggedGradient.lookbackPeriod}
+            onInput={(e) => handleLaggedGradientParamChange('lookbackPeriod', (e.target as HTMLInputElement).value)}
+          />
+        </div>
+        <div className="param-group">
+          <label>Smoothing Factor:</label>
+          <input
+            type="number"
+            step="0.05"
+            min="0"
+            max="1"
+            value={forecasterParams.laggedGradient.smoothingFactor}
+            onInput={(e) => handleLaggedGradientParamChange('smoothingFactor', (e.target as HTMLInputElement).value)}
+          />
+        </div>
+      </div>
+
+      <div className="control-section">
         <h3>Status</h3>
         <div className="status-info">
           <div>Time: {currentTime.toFixed(2)}s</div>
           <div>Rate: 50 ticks/sec</div>
-          <div>Forecast: Lagged Gradient</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This commit introduces the ability for users to customize the parameters for signal generators (Sine Wave and Brownian Motion) and the Lagged Gradient forecaster directly from the Control Panel in the UI.

Changes include:
- Updated `ControlPanel.tsx` to include input fields for all relevant parameters (amplitude, frequency, phase, offset for Sine Wave; volatility, drift, initialValue for Brownian Motion; lookbackPeriod, smoothingFactor for Lagged Gradient Forecaster).
- Modified `App.tsx` to manage the state of these parameters and pass them to the ControlPanel.
- Ensured that generators and forecasters are re-initialized with the new parameters when they are changed in the UI.
- The Brownian Motion generator now correctly resets its internal state if its `initialValue` parameter is changed.
- Parameter input fields are conditionally rendered based on the active signal type.
- Callbacks are used to propagate parameter changes from ControlPanel back to App.tsx.